### PR TITLE
add sync2kafka client library and implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+s2kclient
 /sync2kafka
 sync2kafka.store
 tls.crt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "go.formatTool": "goimports"
-}

--- a/client/connect.go
+++ b/client/connect.go
@@ -1,0 +1,186 @@
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+)
+
+type sync2KafkaClient struct {
+	useTLS             bool
+	insecureSkipVerify bool
+	isTransfering      bool
+	caCert             string
+	target             string
+	conn               net.Conn
+	err                error
+	enc                *json.Encoder
+	dec                *json.Decoder
+	syncInit           *SyncInitInfo
+}
+
+// BinarySync2KafkaClient communicates with sync2kafka with binary encoded messages
+type BinarySync2KafkaClient struct {
+	sync2KafkaClient
+}
+
+type JsonSync2KafkaClient struct {
+	sync2KafkaClient
+}
+
+// NewBinary creates a new binary client for sync2kafaka server  (uses []byte key value messages for input)
+func NewBinary(config *SyncInitInfo, target string, insecureSkipVerify, useTls bool, caCert string) (client *BinarySync2KafkaClient) {
+	config.Format = "binary"
+	return &BinarySync2KafkaClient{
+		*newSync2KafkaClient(useTls, insecureSkipVerify, caCert, target, config),
+	}
+}
+
+// NewJson creates a new json client for sync2kafaka server (uses precomputed json key value messages for input)
+func NewJson(config *SyncInitInfo, target string, insecureSkipVerify, useTls bool, caCert string) (client *JsonSync2KafkaClient) {
+	config.Format = "json"
+	return &JsonSync2KafkaClient{
+		*newSync2KafkaClient(useTls, insecureSkipVerify, caCert, target, config),
+	}
+}
+
+func newSync2KafkaClient(useTls bool, insecureSkipVerify bool, caCert string, target string, config *SyncInitInfo) *sync2KafkaClient {
+	return &sync2KafkaClient{
+		useTLS:             useTls,
+		insecureSkipVerify: insecureSkipVerify,
+		caCert:             caCert,
+		target:             target,
+		conn:               nil,
+		err:                nil,
+		enc:                nil,
+		dec:                nil,
+		syncInit:           config,
+	}
+}
+
+
+
+// Connect connects this sync2kafka client to a sync2kafka server.
+func (c *sync2KafkaClient) Connect(ctx context.Context) (err error) {
+	var d net.Dialer
+
+	// connect to target
+	if !c.useTLS {
+		c.conn, err = d.DialContext(ctx, "tcp", c.target)
+	} else {
+		netConn, _ := d.DialContext(ctx, "tcp", c.target)
+		// tls handshake on open connection (with context)
+		cfg := genTLSConf(c)
+		conn := tls.Client(netConn, cfg)
+		err = conn.Handshake()
+		if err != nil {
+			log.Println("sync2KafkaClient could not connect using tls", err)
+			return
+		}
+		c.conn = conn
+	}
+	c.enc = json.NewEncoder(c.conn)
+	c.dec = json.NewDecoder(c.conn)
+	return
+}
+
+
+func genTLSConf(c *sync2KafkaClient) (config *tls.Config) {
+	if c.insecureSkipVerify {
+		return &tls.Config{
+			InsecureSkipVerify: c.insecureSkipVerify,
+		}
+	}
+
+	// Get the SystemCertPool, continue with an empty pool on error
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	// Append the cert to system certs
+	if len(c.caCert) != 0 {
+		if ok := rootCAs.AppendCertsFromPEM([]byte(c.caCert)); !ok {
+			log.Println("sync2KafkaClient no custom cert appended, using system certs only")
+		}
+	}
+
+	// Trust the augmented cert pool in our client
+	return &tls.Config{
+		InsecureSkipVerify: c.insecureSkipVerify,
+		RootCAs:            rootCAs,
+		ServerName: c.target,
+	}
+
+}
+
+// StartTransfer starts a data transfert session. Endtransfer() must be called after transferring all data
+func (c *sync2KafkaClient) StartTransfer() (err error) {
+	// initialize transfer
+	if err = c.enc.Encode(c.syncInit); err != nil {
+		return errors.New("sync2KafkaClient system init request error" + err.Error())
+	}
+	c.isTransfering = true
+	return
+}
+
+// SendValue send one value in a Transfer session (after calling StartTransfer() and before calling EndTransfer()
+func (c *BinarySync2KafkaClient) SendValue(kv BinaryKV) (err error) {
+		if err = c.enc.Encode(kv); err != nil {
+			return errors.New("sync2KafkaClient request encoding error " + err.Error())
+		}
+	return
+}
+
+// EndTransfer ends a data transfer session
+func (c *BinarySync2KafkaClient) EndTransfer() (err error) {
+	return c.endTransfer(BinaryKV{EndOfTransfer: true})
+}
+
+// EndTransfer ends a data transfer session
+func (c *JsonSync2KafkaClient) EndTransfer() (err error) {
+	return c.endTransfer(JsonKV{EndOfTransfer: true})
+}
+
+func (c *sync2KafkaClient) endTransfer(eof interface {}) (err error) {
+	c.isTransfering = false
+
+	// end transfer
+	if err = c.enc.Encode(eof); err != nil {
+		return errors.New("sync2KafkaClient EndOfTransfer request error " + err.Error())
+	}
+	result := SyncResult{}
+	if err = c.dec.Decode(&result); err != nil {
+		return errors.New("sync2KafkaClient EndOfTransfer response error " + err.Error())
+	}
+	if !result.OK {
+		return fmt.Errorf("sync2KafkaClient result from sync2kafka server is not ok : %v", result)
+	}
+
+	return
+}
+
+
+
+func (c *JsonSync2KafkaClient) Close() error {
+	if c.isTransfering {
+		c.EndTransfer()
+	}
+	return c.conn.Close()
+}
+
+func (c *BinarySync2KafkaClient) Close() error {
+	if c.isTransfering {
+		c.EndTransfer()
+	}
+	return c.conn.Close()
+}
+
+func (c *sync2KafkaClient) Close() error {
+	return c.conn.Close()
+}

--- a/cmd/s2kclient/main.go
+++ b/cmd/s2kclient/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	//"bufio"
+	"context"
+	"flag"
+	"io/ioutil"
+	"log"
+	"time"
+
+	//"os"
+
+	"github.com/antonin07130/sync2kafka/client"
+)
+
+var (
+	useTls     = flag.Bool("use-tls", false, "use TLS connection")
+	skipVerify     = flag.Bool("skip-tls-verify", false, "skip tls verification")
+	tlsCertPath     = flag.String("tls-cert", "", "TLS certificate path (required if key is set)")
+	token             = flag.String("token", "", "sync2kafka server token")
+	server  = flag.String("server", ":9084", "sync2kafka server url")
+	topic             = flag.String("topic", "sync2kafka", "destination topic")
+	sep             = flag.String("separator", " ", "key/value separator (default is space)")
+
+	s2klient *client.BinarySync2KafkaClient
+)
+
+func main() {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	SetupCloseHandler()
+
+	// read cert
+	var crt string
+	if tlsCertPath != nil {
+		crtBytes, err := ioutil.ReadFile(*tlsCertPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		crt = string(crtBytes)
+	}
+
+	s2klient = client.NewBinary(&client.SyncInitInfo{
+		Format:   "",
+		DoDelete: false,
+		Token:    *token,
+		Topic:    *topic,
+	}, *server, *skipVerify, *useTls, crt)
+
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+	err := s2klient.Connect(ctx)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err = s2klient.StartTransfer(); err != nil{
+		log.Fatal(err)
+	}
+
+	for ; ;  {
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		keyvalue := scanner.Text()
+
+		keyvalueSplit := strings.Split(keyvalue, *sep)
+		if keyvalue == "\n" || len(keyvalueSplit) != 2 {
+			break
+		}
+
+		kv := client.BinaryKV{
+			Key:           []byte(keyvalueSplit[0]),
+			Value:         []byte(keyvalueSplit[1]),
+		}
+
+		if err = s2klient.SendValue(kv); err != nil{
+			log.Fatal(err)
+		}
+	}
+
+	if err = s2klient.EndTransfer(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err = s2klient.Close(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func SetupCloseHandler() {
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(c, os.Interrupt, syscall.SIGQUIT)
+	go func() {
+		<-c
+		if s2klient != nil {
+			if err := s2klient.Close(); err != nil {
+				os.Exit(1)
+			}
+		}
+		os.Exit(0)
+	}()
+}

--- a/cmd/sync2kafka/conn.go
+++ b/cmd/sync2kafka/conn.go
@@ -13,7 +13,7 @@ import (
 
 	kafkasync "github.com/mcluseau/kafka-sync"
 
-	"isi.nc/common/sync2kafka/client"
+	"github.com/antonin07130/sync2kafka/client"
 )
 
 const kvBufferSize = 1000
@@ -116,6 +116,7 @@ func handleConn(conn net.Conn) {
 		err = readJsonKVs(dec, kvSource, status)
 
 	case "binary":
+		log.Println("read binary")
 		err = readBinaryKVs(dec, kvSource, status)
 
 	default:

--- a/cmd/sync2kafka/http.go
+++ b/cmd/sync2kafka/http.go
@@ -8,9 +8,8 @@ import (
 
 	restful "github.com/emicklei/go-restful"
 	swaggerui "github.com/mcluseau/go-swagger-ui"
-
-	"isi.nc/common/sync2kafka/apiutils"
-)
+	"github.com/antonin07130/sync2kafka/apiutils"
+	)
 
 const bearerHdr = "Bearer "
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module isi.nc/common/sync2kafka
+module github.com/antonin07130/sync2kafka
 
 require (
 	github.com/Shopify/sarama v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/eapache/go-resiliency v1.2.0 h1:v7g92e/KSN71Rq7vSThKaWIq68fL4YHvWyiUK
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
+github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/emicklei/go-restful v2.9.6+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.11.0+incompatible h1:XfJYmBrweXijz6u2n8jWVAH10Vt7AsYahtOAZepjmGA=


### PR DESCRIPTION
For developing easily an ecosystem of application using sync2kafka.

This commit brings a client library and a sample cli client to speedup development of XXXToSync applications.